### PR TITLE
fix(parsePaymentDestination): Fixed issue for hermes js engine android

### DIFF
--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -246,7 +246,7 @@ const getIntraLedgerPayResponse = ({
   destinationText: string
 }): ValidPaymentReponse => {
   const handle = protocol.match(/^(http|\/\/)/iu)
-    ? destinationText.split("/").at(-1)
+    ? destinationText.split("/")[destinationText.split("/").length - 1]
     : destinationText
 
   if (handle?.match(/(?!^(1|3|bc1|lnbc1))^[0-9a-z_]{3,50}$/iu)) {


### PR DESCRIPTION
hermes js was exhibiting different behaviour between ios/android.  [1,2].at(-1) should return 2 but instead was returning undefined on android.  I've replaced the operation to use one which works the same on both platforms.