### PR TITLE
Workaround for signet external libraries

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -11,6 +11,6 @@ jobs:
     - name: Checkout Actions Repository
       uses: actions/checkout@v2
     - name: Spell Check Repo
-      uses: crate-ci/typos@1.12.12
+      uses: crate-ci/typos@v1.12.12
       with:
         config: typos.toml

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -11,6 +11,6 @@ jobs:
     - name: Checkout Actions Repository
       uses: actions/checkout@v2
     - name: Spell Check Repo
-      uses: crate-ci/typos@master
+      uses: crate-ci/typos@1.12.12
       with:
         config: typos.toml

--- a/src/lnurl/index.ts
+++ b/src/lnurl/index.ts
@@ -42,7 +42,7 @@ export const fetchLnurlInvoice = async ({
 export const isLnurlPaymentSameNode = async ({
   lnUrlOrAddress,
   ourNode,
-  network
+  network,
 }: isLnurlPaymentSameNodeArgs): Promise<boolean> => {
   const { invoice } = await requestInvoice({
     lnUrlOrAddress,

--- a/src/lnurl/index.ts
+++ b/src/lnurl/index.ts
@@ -7,10 +7,12 @@ import {
 } from "lnurl-pay/dist/types/types"
 import { getDestination } from "../parsing"
 import bolt11 from "bolt11"
+import { Network, parseBolt11Network } from "../parsing-v2"
 
 type isLnurlPaymentSameNodeArgs = {
   lnUrlOrAddress: string
   ourNode: string
+  network: Network
 }
 
 export const fetchLnurlPaymentParams = async ({
@@ -40,11 +42,12 @@ export const fetchLnurlInvoice = async ({
 export const isLnurlPaymentSameNode = async ({
   lnUrlOrAddress,
   ourNode,
+  network
 }: isLnurlPaymentSameNodeArgs): Promise<boolean> => {
   const { invoice } = await requestInvoice({
     lnUrlOrAddress,
     tokens: utils.toSats(1),
   })
-  const decoded = bolt11.decode(invoice)
+  const decoded = bolt11.decode(invoice, parseBolt11Network(network))
   return ourNode === getDestination(decoded)
 }

--- a/src/parsing-v2/index.ts
+++ b/src/parsing-v2/index.ts
@@ -18,34 +18,34 @@ const parseBitcoinJsNetwork = (network: string): networks.Network => {
 // This is a hack to get around the fact that bolt11 doesn't support signet
 export const parseBolt11Network = (network: string): bolt11.Network => {
   if (network === "mainnet") {
-        return {
-          bech32: 'bc',
-          pubKeyHash: 0x00,
-          scriptHash: 0x05,
-          validWitnessVersions: [0, 1]
+    return {
+      bech32: "bc",
+      pubKeyHash: 0x00,
+      scriptHash: 0x05,
+      validWitnessVersions: [0, 1],
     }
   } else if (network === "signet") {
-        return {
-      bech32: 'tb',
+    return {
+      bech32: "tb",
       pubKeyHash: 0x6f,
       scriptHash: 0xc4,
-      validWitnessVersions: [0, 1]
+      validWitnessVersions: [0, 1],
     }
   } else if (network === "regtest") {
     return {
-  bech32: 'bcrt',
-  pubKeyHash: 0x6f,
-  scriptHash: 0xc4,
-  validWitnessVersions: [0, 1]
-}
+      bech32: "bcrt",
+      pubKeyHash: 0x6f,
+      scriptHash: 0xc4,
+      validWitnessVersions: [0, 1],
+    }
   }
   return {
-          // default network is bitcoin
-          bech32: 'bc',
-          pubKeyHash: 0x00,
-          scriptHash: 0x05,
-          validWitnessVersions: [0, 1]
-    }
+    // default network is bitcoin
+    bech32: "bc",
+    pubKeyHash: 0x00,
+    scriptHash: 0x05,
+    validWitnessVersions: [0, 1],
+  }
 }
 
 export const getDescription = (decoded: bolt11.PaymentRequestObject) => {
@@ -59,14 +59,16 @@ export const getDestination = (
   decoded: bolt11.PaymentRequestObject,
 ): string | undefined => decoded.payeeNodeKey
 
-export const getHashFromInvoice = (invoice: string, network: Network): string | undefined => {
+export const getHashFromInvoice = (
+  invoice: string,
+  network: Network,
+): string | undefined => {
   const decoded = bolt11.decode(invoice, parseBolt11Network(network))
   const data = decoded.tags.find((value) => value.tagName === "payment_hash")?.data
   if (data) {
     return data as string
   }
 }
-
 
 export enum PaymentType {
   Lightning = "lightning",
@@ -161,7 +163,10 @@ export const getLightningInvoiceExpiryTime = (
   return payReq?.timeExpireDate || NaN
 }
 
-export const decodeInvoiceString = (invoice: string, network: Network): bolt11.PaymentRequestObject => {
+export const decodeInvoiceString = (
+  invoice: string,
+  network: Network,
+): bolt11.PaymentRequestObject => {
   return bolt11.decode(invoice, parseBolt11Network(network))
 }
 

--- a/src/parsing-v2/index.ts
+++ b/src/parsing-v2/index.ts
@@ -3,7 +3,9 @@ import url from "url"
 import { networks, address } from "bitcoinjs-lib"
 import { utils } from "lnurl-pay"
 
-const parseNetwork = (network: string): networks.Network => {
+export type Network = "mainnet" | "signet" | "regtest"
+
+const parseBitcoinJsNetwork = (network: string): networks.Network => {
   if (network === "mainnet") {
     return networks.bitcoin
   } else if (network === "signet") {
@@ -12,6 +14,38 @@ const parseNetwork = (network: string): networks.Network => {
     return networks.regtest
   }
   return networks.bitcoin
+}
+// This is a hack to get around the fact that bolt11 doesn't support signet
+export const parseBolt11Network = (network: string): bolt11.Network => {
+  if (network === "mainnet") {
+        return {
+          bech32: 'bc',
+          pubKeyHash: 0x00,
+          scriptHash: 0x05,
+          validWitnessVersions: [0, 1]
+    }
+  } else if (network === "signet") {
+        return {
+      bech32: 'tb',
+      pubKeyHash: 0x6f,
+      scriptHash: 0xc4,
+      validWitnessVersions: [0, 1]
+    }
+  } else if (network === "regtest") {
+    return {
+  bech32: 'bcrt',
+  pubKeyHash: 0x6f,
+  scriptHash: 0xc4,
+  validWitnessVersions: [0, 1]
+}
+  }
+  return {
+          // default network is bitcoin
+          bech32: 'bc',
+          pubKeyHash: 0x00,
+          scriptHash: 0x05,
+          validWitnessVersions: [0, 1]
+    }
 }
 
 export const getDescription = (decoded: bolt11.PaymentRequestObject) => {
@@ -25,15 +59,15 @@ export const getDestination = (
   decoded: bolt11.PaymentRequestObject,
 ): string | undefined => decoded.payeeNodeKey
 
-export const getHashFromInvoice = (invoice: string): string | undefined => {
-  const decoded = bolt11.decode(invoice)
+export const getHashFromInvoice = (invoice: string, network: Network): string | undefined => {
+  const decoded = bolt11.decode(invoice, parseBolt11Network(network))
   const data = decoded.tags.find((value) => value.tagName === "payment_hash")?.data
   if (data) {
     return data as string
   }
 }
 
-export type Network = "mainnet" | "signet" | "regtest"
+
 export enum PaymentType {
   Lightning = "lightning",
   Intraledger = "intraledger",
@@ -127,8 +161,8 @@ export const getLightningInvoiceExpiryTime = (
   return payReq?.timeExpireDate || NaN
 }
 
-export const decodeInvoiceString = (invoice: string): bolt11.PaymentRequestObject => {
-  return bolt11.decode(invoice)
+export const decodeInvoiceString = (invoice: string, network: Network): bolt11.PaymentRequestObject => {
+  return bolt11.decode(invoice, parseBolt11Network(network))
 }
 
 // from https://github.com/bitcoin/bips/blob/master/bip-0020.mediawiki#Transfer%20amount/size
@@ -316,7 +350,7 @@ const getLightningPayResponse = ({
 
   let payReq: bolt11.PaymentRequestObject | undefined = undefined
   try {
-    payReq = bolt11.decode(lnProtocol)
+    payReq = bolt11.decode(lnProtocol, parseBolt11Network(network))
   } catch (err) {
     return {
       valid: false,
@@ -383,7 +417,7 @@ const getOnChainPayResponse = ({
     }
 
     // will throw if address is not valid
-    address.toOutputScript(path, parseNetwork(network))
+    address.toOutputScript(path, parseBitcoinJsNetwork(network))
     return {
       valid: true,
       paymentType,

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -16,34 +16,34 @@ const parseBitcoinJsNetwork = (network: string): networks.Network => {
 // This is a hack to get around the fact that bolt11 doesn't support signet
 const parseBolt11Network = (network: string): bolt11.Network => {
   if (network === "mainnet") {
-        return {
-          bech32: 'bc',
-          pubKeyHash: 0x00,
-          scriptHash: 0x05,
-          validWitnessVersions: [0, 1]
+    return {
+      bech32: "bc",
+      pubKeyHash: 0x00,
+      scriptHash: 0x05,
+      validWitnessVersions: [0, 1],
     }
   } else if (network === "signet") {
-        return {
-      bech32: 'tb',
+    return {
+      bech32: "tb",
       pubKeyHash: 0x6f,
       scriptHash: 0xc4,
-      validWitnessVersions: [0, 1]
+      validWitnessVersions: [0, 1],
     }
   } else if (network === "regtest") {
     return {
-  bech32: 'bcrt',
-  pubKeyHash: 0x6f,
-  scriptHash: 0xc4,
-  validWitnessVersions: [0, 1]
-}
+      bech32: "bcrt",
+      pubKeyHash: 0x6f,
+      scriptHash: 0xc4,
+      validWitnessVersions: [0, 1],
+    }
   }
   return {
-          // default network is bitcoin
-          bech32: 'bc',
-          pubKeyHash: 0x00,
-          scriptHash: 0x05,
-          validWitnessVersions: [0, 1]
-    }
+    // default network is bitcoin
+    bech32: "bc",
+    pubKeyHash: 0x00,
+    scriptHash: 0x05,
+    validWitnessVersions: [0, 1],
+  }
 }
 
 export const getDescription = (decoded: bolt11.PaymentRequestObject) => {
@@ -57,7 +57,10 @@ export const getDestination = (
   decoded: bolt11.PaymentRequestObject,
 ): string | undefined => decoded.payeeNodeKey
 
-export const getHashFromInvoice = (invoice: string, network?: bolt11.Network): string | undefined => {
+export const getHashFromInvoice = (
+  invoice: string,
+  network?: bolt11.Network,
+): string | undefined => {
   const decoded = bolt11.decode(invoice, network)
   const data = decoded.tags.find((value) => value.tagName === "payment_hash")?.data
   if (data) {
@@ -94,7 +97,10 @@ export const getLightningInvoiceExpiryTime = (
   return payReq?.timeExpireDate || NaN
 }
 
-export const decodeInvoiceString = (invoice: string, network?: bolt11.Network): bolt11.PaymentRequestObject => {
+export const decodeInvoiceString = (
+  invoice: string,
+  network?: bolt11.Network,
+): bolt11.PaymentRequestObject => {
   return bolt11.decode(invoice, network)
 }
 

--- a/src/parsing/index.ts
+++ b/src/parsing/index.ts
@@ -3,7 +3,7 @@ import url from "url"
 import { networks, address } from "bitcoinjs-lib"
 import { utils } from "lnurl-pay"
 
-const parseNetwork = (network: string): networks.Network => {
+const parseBitcoinJsNetwork = (network: string): networks.Network => {
   if (network === "mainnet") {
     return networks.bitcoin
   } else if (network === "signet") {
@@ -12,6 +12,38 @@ const parseNetwork = (network: string): networks.Network => {
     return networks.regtest
   }
   return networks.bitcoin
+}
+// This is a hack to get around the fact that bolt11 doesn't support signet
+const parseBolt11Network = (network: string): bolt11.Network => {
+  if (network === "mainnet") {
+        return {
+          bech32: 'bc',
+          pubKeyHash: 0x00,
+          scriptHash: 0x05,
+          validWitnessVersions: [0, 1]
+    }
+  } else if (network === "signet") {
+        return {
+      bech32: 'tb',
+      pubKeyHash: 0x6f,
+      scriptHash: 0xc4,
+      validWitnessVersions: [0, 1]
+    }
+  } else if (network === "regtest") {
+    return {
+  bech32: 'bcrt',
+  pubKeyHash: 0x6f,
+  scriptHash: 0xc4,
+  validWitnessVersions: [0, 1]
+}
+  }
+  return {
+          // default network is bitcoin
+          bech32: 'bc',
+          pubKeyHash: 0x00,
+          scriptHash: 0x05,
+          validWitnessVersions: [0, 1]
+    }
 }
 
 export const getDescription = (decoded: bolt11.PaymentRequestObject) => {
@@ -25,8 +57,8 @@ export const getDestination = (
   decoded: bolt11.PaymentRequestObject,
 ): string | undefined => decoded.payeeNodeKey
 
-export const getHashFromInvoice = (invoice: string): string | undefined => {
-  const decoded = bolt11.decode(invoice)
+export const getHashFromInvoice = (invoice: string, network?: bolt11.Network): string | undefined => {
+  const decoded = bolt11.decode(invoice, network)
   const data = decoded.tags.find((value) => value.tagName === "payment_hash")?.data
   if (data) {
     return data as string
@@ -62,8 +94,8 @@ export const getLightningInvoiceExpiryTime = (
   return payReq?.timeExpireDate || NaN
 }
 
-export const decodeInvoiceString = (invoice: string): bolt11.PaymentRequestObject => {
-  return bolt11.decode(invoice)
+export const decodeInvoiceString = (invoice: string, network?: bolt11.Network): bolt11.PaymentRequestObject => {
+  return bolt11.decode(invoice, network)
 }
 
 // from https://github.com/bitcoin/bips/blob/master/bip-0020.mediawiki#Transfer%20amount/size
@@ -173,7 +205,7 @@ const getLightningPayResponse = ({
 
   let payReq: bolt11.PaymentRequestObject | undefined = undefined
   try {
-    payReq = bolt11.decode(lnProtocol)
+    payReq = bolt11.decode(lnProtocol, parseBolt11Network(network))
   } catch (err) {
     return {
       valid: false,
@@ -243,7 +275,7 @@ const getOnChainPayResponse = ({
     }
 
     // will throw if address is not valid
-    address.toOutputScript(path, parseNetwork(network))
+    address.toOutputScript(path, parseBitcoinJsNetwork(network))
     return {
       valid: true,
       paymentType: "onchain",


### PR DESCRIPTION
Neither `bolt11` or `bitcoinjs-lib` support signet as a known network.  The recommended approach from one of the maintainers is to pass in a custom network so I've created some parsing methods to pass in the correctly typed objects to the method calls for those libraries.

https://github.com/bitcoinjs/bolt11/pull/58#issuecomment-1106495709