### PR TITLE
feat: add mobile versions query

### DIFF
--- a/src/graphql/gql_operations.ts
+++ b/src/graphql/gql_operations.ts
@@ -3141,6 +3141,12 @@ var main = {
                 },
                 {
                   kind: "Field",
+                  name: { kind: "Name", value: "network" },
+                  arguments: [],
+                  directives: [],
+                },
+                {
+                  kind: "Field",
                   name: { kind: "Name", value: "lightningAddressDomain" },
                   arguments: [],
                   directives: [],
@@ -3220,9 +3226,70 @@ var main = {
   ],
   loc: {
     start: 0,
-    end: 251,
+    end: 263,
     source: {
-      body: "query main($isAuthenticated: Boolean!, $recentTransactions: Int) {\n  globals {\n    nodesIds\n    lightningAddressDomain\n  }\n  btcPrice {\n    base\n    offset\n    currencyUnit\n    formattedAmount\n  }\n  me @include(if: $isAuthenticated) {\n    ...Me\n  }\n}\n",
+      body: "query main($isAuthenticated: Boolean!, $recentTransactions: Int) {\n  globals {\n    nodesIds\n    network\n    lightningAddressDomain\n  }\n  btcPrice {\n    base\n    offset\n    currencyUnit\n    formattedAmount\n  }\n  me @include(if: $isAuthenticated) {\n    ...Me\n  }\n}\n",
+      name: "GraphQL request",
+      locationOffset: { line: 1, column: 1 },
+    },
+  },
+}
+var mobileVersions = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "mobileVersions" },
+      variableDefinitions: [],
+      directives: [],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "mobileVersions" },
+            arguments: [],
+            directives: [],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "__typename" },
+                  arguments: [],
+                  directives: [],
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "platform" },
+                  arguments: [],
+                  directives: [],
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "currentSupported" },
+                  arguments: [],
+                  directives: [],
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "minSupported" },
+                  arguments: [],
+                  directives: [],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+  loc: {
+    start: 0,
+    end: 114,
+    source: {
+      body: "query mobileVersions {\n  mobileVersions {\n    __typename\n    platform\n    currentSupported\n    minSupported\n  }\n}\n",
       name: "GraphQL request",
       locationOffset: { line: 1, column: 1 },
     },
@@ -4420,6 +4487,7 @@ const QUERIES = {
   contacts,
   getWalletCsvTransactions,
   main,
+  mobileVersions,
   onChainTxFee,
   quizQuestions,
   transactionList,

--- a/src/graphql/gql_operations.ts.source
+++ b/src/graphql/gql_operations.ts.source
@@ -40,6 +40,7 @@ const SUBSCRIPTIONS = { myUpdates, lnInvoicePaymentStatus }
 
 
 import main from "./queries/main.gql"
+import mobileVersions from "./queries/mobile-versions.gql"
 import transactionList from "./queries/transaction-list.gql"
 import transactionListForContact from "./queries/transaction-list.gql"
 import transactionListForDefaultAccount from "./queries/transaction-list.gql"
@@ -61,6 +62,7 @@ const QUERIES = {
   contacts,
   getWalletCsvTransactions,
   main,
+  mobileVersions,
   onChainTxFee,
   quizQuestions,
   transactionList,

--- a/src/graphql/queries/main.gql
+++ b/src/graphql/queries/main.gql
@@ -1,6 +1,7 @@
 query main($isAuthenticated: Boolean!, $recentTransactions: Int) {
   globals {
     nodesIds
+    network
     lightningAddressDomain
   }
   btcPrice {

--- a/src/graphql/queries/mobile-versions.gql
+++ b/src/graphql/queries/mobile-versions.gql
@@ -1,0 +1,8 @@
+query mobileVersions {
+  mobileVersions {
+    __typename
+    platform
+    currentSupported
+    minSupported
+  }
+}

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -1959,6 +1959,7 @@ export namespace GaloyGQL {
     readonly globals?: {
       readonly __typename?: "Globals"
       readonly nodesIds: ReadonlyArray<string>
+      readonly network: Network
       readonly lightningAddressDomain: string
     } | null
     readonly btcPrice?: {
@@ -2051,6 +2052,18 @@ export namespace GaloyGQL {
         >
       }
     } | null
+  }
+
+  export type MobileVersionsQueryVariables = Exact<{ [key: string]: never }>
+
+  export type MobileVersionsQuery = {
+    readonly __typename?: "Query"
+    readonly mobileVersions?: ReadonlyArray<{
+      readonly __typename: "MobileVersions"
+      readonly platform: string
+      readonly currentSupported: number
+      readonly minSupported: number
+    } | null> | null
   }
 
   export type OnChainTxFeeQueryVariables = Exact<{

--- a/src/graphql/use-query.ts
+++ b/src/graphql/use-query.ts
@@ -66,6 +66,19 @@ const accountDefaultWalletQuery = (
   >("accountDefaultWallet", config)
 }
 
+const mobileVersionsQuery = (
+  config?: QueryHookOptions<
+    GaloyGQL.MobileVersionsQuery,
+    GaloyGQL.MobileVersionsQueryVariables
+  >,
+): QueryResult<GaloyGQL.MobileVersionsQuery, GaloyGQL.MobileVersionsQueryVariables> &
+  QueryHelpers => {
+  return useQueryWrapper<
+    GaloyGQL.MobileVersionsQuery,
+    GaloyGQL.MobileVersionsQueryVariables
+  >("mobileVersions", config)
+}
+
 const transactionListQuery = (
   config?: QueryHookOptions<
     GaloyGQL.TransactionListQuery,
@@ -120,6 +133,7 @@ export const useQuery = {
   accountDefaultWallet: accountDefaultWalletQuery,
   contacts: contactsQuery,
   main: mainQuery,
+  mobileVersions: mobileVersionsQuery,
   onChainTxFee: onChainTxFeeQuery,
   transactionList: transactionListQuery,
   transactionListForContact: transactionListForContactQuery,
@@ -208,6 +222,19 @@ const contactsDelayedQuery = (
   )
 }
 
+const mobileVersionsDelayedQuery = (
+  config?: QueryHookOptions<
+    GaloyGQL.MobileVersionsQuery,
+    GaloyGQL.MobileVersionsQueryVariables
+  >,
+): QueryResult<GaloyGQL.MobileVersionsQuery, GaloyGQL.MobileVersionsQueryVariables> &
+  QueryHelpers => {
+  return useQueryWrapper<
+    GaloyGQL.MobileVersionsQuery,
+    GaloyGQL.MobileVersionsQueryVariables
+  >("mobileVersions", config)
+}
+
 const transactionListDelayedQuery = (
   config?: QueryOptions<
     GaloyGQL.TransactionListQuery,
@@ -243,9 +270,10 @@ const onChainTxFeeDelayedQuery = (
 
 export const useDelayedQuery = {
   accountDefaultWallet: accountDefaultWalletDelayedQuery,
+  contacts: contactsDelayedQuery,
+  mobileVersions: mobileVersionsDelayedQuery,
   onChainTxFee: onChainTxFeeDelayedQuery,
   transactionList: transactionListDelayedQuery,
   transactionListForContact: transactionListForContactDelayedQuery,
   userDefaultWalletId: userDefaultWalletIdDelayedQuery,
-  contacts: contactsDelayedQuery,
 }


### PR DESCRIPTION
Currently, this query is under on the main query [here](https://github.com/GaloyMoney/galoy-mobile/blob/859c290ac5b81c5d55495860eb722816db0a4b93/app/graphql/query.ts#L106) in the mobile app which doesn't use the Galoy client query. This is needed to successfully migrate the queries in the mobile app to use the Galoy client. 